### PR TITLE
Add styles 'italic' and 'strikethrough' and test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ use colorful::Colorful;
 fn main() {
     let s = "Hello world";
     println!("{}", s.color(Color::Blue).bg_color(Color::Yellow).bold());
-    //     println!("{}", s.color(HSL::new(1.0, 1.0, 0.5)).bold());
+    //     println!("{}", s.color(HSL::new(1.0, 1.0, 0.5)).italic());
     //     println!("{}", s.color(RGB::new(255, 0, 0)).bold());
     println!("{}", s.blue().bg_yellow());
 }

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -8,7 +8,7 @@ use colorful::RGB;
 fn main() {
     let s = "Hello world";
     println!("{}", s.color(Color::Blue).bg_color(Color::Yellow).bold());
-    println!("{}", s.color(HSL::new(1.0, 1.0, 0.5)).bold());
+    println!("{}", s.color(HSL::new(1.0, 1.0, 0.5)).italic());
     println!("{}", s.color(RGB::new(255, 0, 0)).bold());
     println!("{}", s.blue().bg_yellow());
 }

--- a/src/core/style.rs
+++ b/src/core/style.rs
@@ -2,12 +2,14 @@
 pub enum Style {
     Bold,
     Dim,
+    Italic,
     Underlined,
     Blink,
     // invert the foreground and background colors
     Reverse,
     // useful for passwords
     Hidden,
+    Strikethrough,
 }
 
 impl Style {
@@ -15,10 +17,12 @@ impl Style {
         match self {
             Style::Bold => String::from("1"),
             Style::Dim => String::from("2"),
+            Style::Italic => String::from("3"),
             Style::Underlined => String::from("4"),
             Style::Blink => String::from("5"),
             Style::Reverse => String::from("7"),
             Style::Hidden => String::from("8"),
+            Style::Strikethrough => String::from("9"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,12 +122,16 @@ pub trait Colorful {
     fn blink(self) -> CString;
     /// Turn low intensity mode on.
     fn dim(self) -> CString;
+    /// Turn italic mode on.
+    fn italic(self) -> CString;
     /// Turn underline mode on.
     fn underlined(self) -> CString;
     /// Turn reverse mode on (invert the foreground and background colors).
     fn reverse(self) -> CString;
     /// Turn invisible text mode on (useful for passwords).
     fn hidden(self) -> CString;
+    /// Turn strikethrough mode on.
+    fn strikethrough(self) -> CString;
     /// Apply gradient color to sentences, support multiple lines.
     /// You can use `use colorful::Color;` or `use colorful::HSL;` or `use colorful::RGB;`
     /// to import colors and create gradient string.
@@ -215,9 +219,11 @@ impl<T> Colorful for T where T: StrMarker {
     fn bold(self) -> CString { self.style(Style::Bold) }
     fn blink(self) -> CString { self.style(Style::Blink) }
     fn dim(self) -> CString { self.style(Style::Dim) }
+    fn italic(self) -> CString { self.style(Style::Italic) }
     fn underlined(self) -> CString { self.style(Style::Underlined) }
     fn reverse(self) -> CString { self.style(Style::Reverse) }
     fn hidden(self) -> CString { self.style(Style::Hidden) }
+    fn strikethrough(self) -> CString { self.style(Style::Strikethrough) }
     fn gradient_with_step<C: ColorInterface>(self, color: C, step: f32) -> CString {
         let mut t = vec![];
         let mut start = color.to_hsl().h;

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -31,6 +31,7 @@ fn test_style() {
     let s = "Hello world";
     assert_eq!("\x1B[1mHello world\x1B[0m".to_owned(), s.style(Style::Bold).to_string());
     assert_eq!("\x1B[1;5mHello world\x1B[0m".to_owned(), s.style(Style::Bold).style(Style::Blink).to_string());
+    assert_eq!("\x1B[3;9mHello world\x1B[0m".to_owned(), s.style(Style::Italic).style(Style::Strikethrough).to_string());
 }
 
 #[test]


### PR DESCRIPTION
Adds the missing styles 'italic' and 'strikethrough'.

This closes #25 

It also duplicates the PR #26 which is stated out-of-date by the maintainer. I am very sorry for I do not know how to get on board of a PR that is not mine. I which this one could credit PR #26 author too.

Compared to #26 this PR also: 
- add a test for the two new styles
- add `.italic()` (the most widely supported style) in the basic_examples, and hence in the readme

It does not: expands the shell "support" matrix at the end of the readme since I could not get that info.