### PR TITLE
Support for NO_COLOR and CLICOLOR / CLICOLOR_FORCE env variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ Output
 </div>
 
 
+## ANSI Support
+
+This crate respects the NO_COLOR env variable (see [the specs](https://no-color.org/)).  
+This crate respects the CLICOLOR and CLICOLOR_FORCE env variable (see [the specs](https://bixense.com/clicolors/)).
+
 ## Terminals compatibility
 
 <table style="font-size: 60%; padding: 1px;">

--- a/src/core/color_string.rs
+++ b/src/core/color_string.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 
-use core::ColorInterface;
+use core::{ColorInterface, ansi_support};
 use core::colors::Colorado;
 use core::colors::ColorMode;
 use core::StrMarker;
@@ -69,10 +69,11 @@ impl CString {
 }
 
 impl Display for CString {
+
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         let mut is_colored = false;
 
-        if self.bg_color.is_none() && self.fg_color.is_none() && self.styles.is_none() {
+        if !ansi_support() || (self.bg_color.is_none() && self.fg_color.is_none() && self.styles.is_none()) {
             write!(f, "{}", self.text)?;
             Ok(())
         } else {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,3 +1,4 @@
+use std::env;
 use core::colors::Colorado;
 use core::style::Style;
 use HSL;
@@ -9,6 +10,45 @@ pub mod style;
 pub mod color_string;
 pub mod rgb;
 pub mod hsl;
+
+/// Reads environment variables to determine whether colorization should
+/// be used or not. `CLICOLOR_FORCE` takes highest priority, followed by
+/// `NO_COLOR`, followed by `CLICOLOR`. In the absence of manual overrides,
+/// which take precedence over all environment variables, the priority
+/// of these variables can be expressed as follows.
+///
+/// `NO_COLOR`      | `CLICOLOR`       | `CLICOLOR_FORCE`   | colorize?
+/// :---------      | :---------       | :---------------   | :--------
+/// unset/`== 0`    | unset            | unset              | true (default)
+/// unset/`== 0`    | `!= 0`           | unset              | true
+/// unset/`== 0`    | `== 0`           | unset              | false
+/// unset/`== 0`    | any              | `== 0`             | false
+/// unset/`== 0`    | any              | `!= 0`             | true
+/// `!= 0`          | any              | any                | true
+/// see https://bixense.com/clicolors/
+/// see https://no-color.org/
+pub fn ansi_support() -> bool {
+    // NO_COLOR unset or "0" => explicit do not support ansi
+    match env::var("NO_COLOR").as_deref() {
+        Ok("0") | Err(_) => true,
+        Ok(_) => return false,
+    };
+    // CLICOLOR_FORCE is "0" => explicit do not support ansi
+    // CLICOLOR_FORCE is "1" => explicit support ansi
+    match env::var("CLICOLOR_FORCE").as_deref() {
+        Ok("0") => return false,
+        Ok(_) => return true,
+        Err(_) => true,
+    };
+    // CLICOLOR is "0" => explicit do not support ansi
+    // CLICOLOR is "1" => explicit support ansi
+    match env::var("CLICOLOR").as_deref() {
+        Ok("0") => return false,
+        Ok(_) => return true,
+        Err(_) => true,
+    };
+    true
+}
 
 pub trait StrMarker {
     fn to_str(&self) -> String;

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -3,11 +3,73 @@ extern crate core;
 
 use colorful::Colorful;
 use colorful::Color;
+use colorful::core::ansi_support;
 use colorful::Style;
 
 #[test]
 fn test_1() {
     assert_eq!("\u{1b}", "\x1B");
+}
+
+#[test]
+fn test_no_ansi_support() {
+    let s = "Hello world";
+
+    // Test set:
+    // `scenario` | `NO_COLOR`      | `CLICOLOR`       | `CLICOLOR_FORCE`   | colorize?
+    // :--------- | :---------      | :---------       | :---------------   | :--------
+    //      1     | unset/`== 0`    | unset            | unset              | true (default)
+    //      2     | unset/`== 0`    | `!= 0`           | unset              | true
+    //      3     | unset/`== 0`    | `== 0`           | unset              | false
+    //      4     | unset/`== 0`    | any              | `== 0`             | false
+    //      5     | unset/`== 0`    | any              | `!= 0`             | true
+    //      6     | `!= 0`          | any              | any                | true
+    // see https://bixense.com/clicolors/
+    // see https://no-color.org/
+
+    // Scenario 1:
+    assert!(ansi_support());
+    assert_eq!("\x1B[38;5;1mHello world\x1B[0m".to_owned(), s.color(Color::Red).to_string());
+
+    // Scenario 2:
+    std::env::set_var("NO_COLOR", "0");
+    std::env::set_var("CLICOLOR", "XXX");
+    assert!(ansi_support());
+    assert_eq!("\x1B[38;5;1mHello world\x1B[0m".to_owned(), s.color(Color::Red).to_string());
+
+    // Scenario 2:
+    std::env::set_var("CLICOLOR", "XXX");
+    assert!(ansi_support());
+    assert_eq!("\x1B[38;5;1mHello world\x1B[0m".to_owned(), s.color(Color::Red).to_string());
+
+    // Scenario 3:
+    std::env::set_var("CLICOLOR", "0");
+    assert!(!ansi_support());
+    assert_eq!("Hello world".to_owned(), s.color(Color::Red).to_string());
+
+    // Scenario 4:
+    std::env::set_var("CLICOLOR", "XXX");
+    std::env::set_var("CLICOLOR_FORCE", "0");
+    assert!(!ansi_support());
+    assert_eq!("Hello world".to_owned(), s.color(Color::Red).to_string());
+
+    // Scenario 5:
+    std::env::set_var("CLICOLOR_FORCE", "XXX");
+    assert!(ansi_support());
+    assert_eq!("\x1B[38;5;1mHello world\x1B[0m".to_owned(), s.color(Color::Red).to_string());
+
+    // Scenario 5:
+    std::env::set_var("NO_COLOR", "1");
+    std::env::set_var("CLICOLOR", "XXX");
+    std::env::set_var("CLICOLOR_FORCE", "XXX");
+    assert!(!ansi_support());
+    assert_eq!("Hello world".to_owned(), s.color(Color::Red).to_string());
+
+    std::env::remove_var("NO_COLOR");
+    std::env::remove_var("CLICOLOR");
+    std::env::remove_var("CLICOLOR_FORCE");
+    assert!(ansi_support());
+    assert_eq!("\x1B[38;5;1mHello world\x1B[0m".to_owned(), s.color(Color::Red).to_string());
 }
 
 #[test]


### PR DESCRIPTION
This PR add respect for env variables regarding ansi support: 
- NO_COLOR (see [the sepcs](https://no-color.org/))
- CLICOLOR and CLICOLOR_FORCE (see [the sepcs](https://bixense.com/clicolors/))

It solves the issue #22 

The PR also adds a readme update as well as tests regarding the env variable support and precedence rules.
The support order and rule of precedence for the env variables are given in the code comments.